### PR TITLE
Add support for Django 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,9 @@ env:
   global:
   - DISPLAY=:99.0
   matrix:
-  - DJANGO="Django<1.9,>=1.8"
-  - DJANGO="Django<1.11,>=1.10"
-  - DJANGO="Django<2.0>=1.11"
+  - DJANGO="Django~=1.8.0"
+  - DJANGO="Django~=1.10.0"
+  - DJANGO="Django~=1.11.0"
   - DJANGO="-e git+https://github.com/django/django.git@master#egg=Django"
 matrix:
   fast_finish: true

--- a/django_phaxio/signals.py
+++ b/django_phaxio/signals.py
@@ -31,7 +31,8 @@ Example::
 
 
     @receiver(phaxio_callback, sender=PhaxioCallbackView)
-    def my_webhook_handler(sender, direction, fax, metadata, is_test, **kwargs):
+    def my_webhook_handler(
+            sender, direction, fax, metadata, is_test, **kwargs):
         # Do something
         pass
 

--- a/django_phaxio/urls.py
+++ b/django_phaxio/urls.py
@@ -2,6 +2,10 @@ from django.conf.urls import url
 
 from . import views
 
+# Set application namespace (Django 2.0+)
+# https://docs.djangoproject.com/en/dev/topics/http/urls/#url-namespaces-and-included-urlconfs
+app_name = 'django_phaxio'
+
 urlpatterns = [
     url(r'^callback$',
         views.PhaxioCallbackView.as_view(),

--- a/django_phaxio/views.py
+++ b/django_phaxio/views.py
@@ -39,7 +39,8 @@ class PhaxioCallbackView(View):
     def dispatch(self, request, *args, **kwargs):
         """Disable CSRF but enable token based security."""
         self.validate_signature(request)
-        return super(PhaxioCallbackView, self).dispatch(request, *args, **kwargs)
+        return super(PhaxioCallbackView, self).dispatch(
+            request, *args, **kwargs)
 
     def post(self, request):
         """Process WebHook and send :func:`.phaxio_callback` signal."""
@@ -64,13 +65,16 @@ class PhaxioCallbackView(View):
         The signature is stored in the header ``X-Phaxio-Signature``.
 
         Raises:
-            PermissionDenied: If provided signature and calculated signature do not match.
+            PermissionDenied: If provided signature and calculated
+            signature do not match.
 
         """
         try:
             signature = request.META['HTTP_X_PHAXIO_SIGNATURE']
         except KeyError:
-            logger.warn('The request header did not include a signature (X-Phaxio-Signature).')
+            logger.warning(
+                'The request header did not include '
+                'a signature (X-Phaxio-Signature).')
             raise PermissionDenied
 
         token = settings.PHAXIO_CALLBACK_TOKEN
@@ -87,10 +91,11 @@ class PhaxioCallbackView(View):
             file_hash = hashlib.sha1()
             file_hash.update(files[filename].read())
             url += '{}{}'.format(filename, file_hash.hexdigest())
-        expected_signature = hmac.new(key=token.encode('utf-8'), msg=url.encode('utf-8'),
-                                      digestmod=hashlib.sha1).hexdigest()
+        expected_signature = hmac.new(
+            key=token.encode('utf-8'), msg=url.encode('utf-8'),
+            digestmod=hashlib.sha1).hexdigest()
         if signature != expected_signature:
-            logger.warn(
+            logger.warning(
                 "Request signature did not match.\n"
                 "Expected signature: %s\n"
                 "Received signature: %s\n",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -52,6 +52,7 @@ def linkcode_resolve(domain, info):
     return ("https://github.com/%s/%s/blob/%s/%s.py%s" %
             (github_user, project, head, filename, lineno))
 
+
 intersphinx_mapping = {
     'python': ('http://docs.python.org/3.5', None),
     'django': ('https://docs.djangoproject.com/en/dev/',

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,5 +1,4 @@
 -e .
-Django
 flake8
 pep8-naming
 mccabe

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,7 +9,6 @@ alabaster==0.7.10 # via sphinx
 babel==2.4.0              # via sphinx
 click==6.7 # via pip-tools
 django-appconf==1.0.2
-Django==1.11
 docutils==0.13.1 # via sphinx
 first==2.0.1              # via pip-tools
 flake8==3.3.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
-[pytest]
+[tool:pytest]
 norecursedirs = env .tox
 addopts = --tb=short -rxs --nomigrations
 DJANGO_SETTINGS_MODULE=tests.testapp.settings

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -74,6 +74,9 @@ class TestPhaxioCallbackView(object):
         assert response.status_code == 200
 
     def test_invalid_signature(self, valid_request, caplog):
+        # Django's QueryDict is immutable, so make a copy first
+        valid_request.POST = valid_request.POST.copy()
+
         valid_request.POST['is_test'] = 'true'
         with pytest.raises(PermissionDenied):
             PhaxioCallbackView.as_view()(valid_request)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -4,13 +4,19 @@ import json
 
 import pytest
 from django.core.exceptions import PermissionDenied
-from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
 from django.utils.six import BytesIO, text_type
 
 from django_phaxio.signals import phaxio_callback
 from django_phaxio.views import DIRECTION, PhaxioCallbackView
+
 from tests.testapp import settings
+
+try:
+    # Django 1.10+
+    from django.urls import reverse
+except ImportError:
+    from django.core.urlresolvers import reverse
 
 
 def create_valid_signature(url, parameters, files):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -105,7 +105,8 @@ class TestPhaxioCallbackView(object):
         assert text_type(e).endswith('signal received')
 
     def test_signal_kwargs(self, valid_request):
-        def signal_receiver(sender, direction, fax, is_test, metadata, **kwargs):
+        def signal_receiver(
+                sender, direction, fax, is_test, metadata, **kwargs):
             assert direction == DIRECTION.received
             assert not is_test
             assert fax == fax_data
@@ -128,5 +129,6 @@ class TestPhaxioCallbackView(object):
         request = rf.post(url, data)
         with pytest.raises(PermissionDenied):
             PhaxioCallbackView.as_view()(request)
-        msg = "The request header did not include a signature (X-Phaxio-Signature)."
+        msg = ("The request header did not include a signature "
+               "(X-Phaxio-Signature).")
         assert msg in caplog.text()

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,11 @@
 [tox]
-envlist = py{34,35}-django{18,19,master},qa
+envlist = py{34,35}-django{18,110,111,master},qa
 [testenv]
 deps=
     -rrequirements-dev.txt
-    django18: Django>=1.8,<1.9
-    django19: Django>=1.10,<1.11
+    django18: Django~=1.8.0
+    django110: Django~=1.10.0
+    django111: Django~=1.11.0
     djangomaster: -egit+https://github.com/django/django.git@master#egg=Django
 setenv =
     PYTHONPATH = {toxinidir}

--- a/tox.ini
+++ b/tox.ini
@@ -22,4 +22,4 @@ deps=
 commands=
     isort --check-only --recursive --diff {posargs}
     flake8 --jobs=2 {posargs}
-    pep257 --verbose --explain --source --count {posargs}
+    pydocstyle --explain --source --count {posargs}


### PR DESCRIPTION
This pull request was motivated by https://github.com/Thermondo/django-phaxio/issues/49. I took the occasion to tidy up a bit - `tox` works again, traces of `pep257` were removed, and some deprecation and style warnings were fixed. As it stands, it now also works with Django master.