### PR TITLE
Replace deprecated `django.conf.urls.url` with `django.urls.path`

### DIFF
--- a/django_phaxio/urls.py
+++ b/django_phaxio/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from django.urls import path
 
 from . import views
 
@@ -7,7 +7,9 @@ from . import views
 app_name = 'django_phaxio'
 
 urlpatterns = [
-    url(r'^callback$',
+    path(
+        'callback/',
         views.PhaxioCallbackView.as_view(),
-        name='callback'),
+        name='callback'
+    ),
 ]


### PR DESCRIPTION
https://docs.djangoproject.com/en/3.2/ref/urls/#url

```
RemovedInDjango40Warning: django.conf.urls.url() is deprecated in favor of django.urls.re_path().
```